### PR TITLE
[STEP 12] 차용한 동시성 제어 및 통합테스트 검증코드

### DIFF
--- a/src/test/java/com/hhplus/commerce/_3weeks/domain/order/OrderConcurrentlyTest.java
+++ b/src/test/java/com/hhplus/commerce/_3weeks/domain/order/OrderConcurrentlyTest.java
@@ -8,6 +8,7 @@ import com.hhplus.commerce._3weeks.domain.product.Product;
 import com.hhplus.commerce._3weeks.domain.product.ProductService;
 import com.hhplus.commerce._3weeks.domain.user.UserService;
 import com.hhplus.commerce._3weeks.infra.user.UserEntity;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,6 +148,7 @@ public class OrderConcurrentlyTest {
     }
 
     @Test
+    @DisplayName("Redisson 활용 동시성 테스트")
     void Redisson_재고_100개_상품에_101번의_주문시도() throws InterruptedException {
 
         int threadCount = 101;


### PR DESCRIPTION
### 적용 내용 
- Redis pub/sub 적용
  - STEP11 에서 동시성 제어 및 성능을 분석한 결과 Redisson을 활용하게 되었습니다.

### Redisson을 채택한 이유
- Redis 서버의 부담을 줄이고 싶었습니다
- Lettuce의 성능이 생각보다 낮기도했으며, 어김없이 혼자 retry로 계속 돌아가는게 싫었습니다
- 성능이 가장 빠르게 나온 DB 락의 경우, 다중 인스턴스 환경에서는 맞지 않다고 느껴 Redisson 분산 락을 채택했습니다.

### 검증코드
주문에 관한 Redisson 동시성 제어 - [통합 테스트](https://github.com/JGwanghou/hhplus-ecommerce/commit/15fed34cf5d478e26211fea0fc548df14aae76a8#diff-ccce4c467c286f5d7dc3d8a5191426718d50f23a2b1c404dbd4c66c506e2b9e7)


